### PR TITLE
Improve consistency of error messages

### DIFF
--- a/src/main/java/dash/commons/util/StringUtil.java
+++ b/src/main/java/dash/commons/util/StringUtil.java
@@ -49,21 +49,15 @@ public class StringUtil {
     }
 
     /**
-     * Returns true if {@code s} represents a non-zero unsigned integer
-     * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Returns true if {@code s} is numeric.
+     * e.g. 1, 2.5, -1, 2147483648<br>
      * Will return false for any other non-null string input
-     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * e.g. "" (empty string), " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters), +1 (contains +)
      *
      * @throws NullPointerException if {@code s} is null.
      */
-    public static boolean isNonZeroUnsignedInteger(String s) {
+    public static boolean isNumeric(String s) {
         requireNonNull(s);
-
-        try {
-            int value = Integer.parseInt(s);
-            return value > 0 && !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
-        } catch (NumberFormatException nfe) {
-            return false;
-        }
+        return s.matches("-?\\d+(\\.\\d+)?");
     }
 }

--- a/src/main/java/dash/logic/parser/ParserUtil.java
+++ b/src/main/java/dash/logic/parser/ParserUtil.java
@@ -25,20 +25,25 @@ import dash.model.task.TaskDescription;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_NON_NUMERIC_INDEX = "Index is not numeric";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
      *
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
+     * @throws ParseException if the specified index is not numeric.
+     * @throws NumberFormatException if the specified index is negative, above INT_MAX_VALUE, or is fractional.
      */
-    public static Index parseIndex(String oneBasedIndex) throws ParseException {
+    public static Index parseIndex(String oneBasedIndex) throws ParseException, NumberFormatException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+        if (!StringUtil.isNumeric(trimmedIndex)) {
+            throw new ParseException(MESSAGE_NON_NUMERIC_INDEX);
         }
-        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+        int index = Integer.parseInt(trimmedIndex);
+        if (!(index > 0)) {
+            throw new NumberFormatException();
+        }
+        return Index.fromOneBased(index);
     }
 
     /**
@@ -173,7 +178,8 @@ public class ParserUtil {
      *
      * @throws ParseException if the any given index is invalid.
      */
-    public static Set<Index> parsePersonIndex(Collection<String> personIndices) throws ParseException {
+    public static Set<Index> parsePersonIndex(Collection<String> personIndices)
+            throws ParseException, NumberFormatException {
         requireNonNull(personIndices);
         final Set<Index> indexSet = new HashSet<>();
         for (String index : personIndices) {

--- a/src/main/java/dash/logic/parser/personcommand/DeletePersonCommandParser.java
+++ b/src/main/java/dash/logic/parser/personcommand/DeletePersonCommandParser.java
@@ -1,6 +1,7 @@
 package dash.logic.parser.personcommand;
 
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
 import dash.commons.core.index.Index;
 import dash.logic.commands.personcommand.DeletePersonCommand;
@@ -26,6 +27,8 @@ public class DeletePersonCommandParser implements Parser<DeletePersonCommand> {
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
     }
 

--- a/src/main/java/dash/logic/parser/personcommand/EditPersonCommandParser.java
+++ b/src/main/java/dash/logic/parser/personcommand/EditPersonCommandParser.java
@@ -2,6 +2,7 @@ package dash.logic.parser.personcommand;
 
 import static dash.commons.core.Messages.MESSAGE_ARGUMENT_EMPTY;
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static dash.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static dash.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static dash.logic.parser.CliSyntax.PREFIX_NAME;
@@ -48,6 +49,8 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditPersonCommand.MESSAGE_USAGE),
                     pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/dash/logic/parser/personcommand/TagPersonCommandParser.java
+++ b/src/main/java/dash/logic/parser/personcommand/TagPersonCommandParser.java
@@ -2,6 +2,7 @@ package dash.logic.parser.personcommand;
 
 import static dash.commons.core.Messages.MESSAGE_ARGUMENT_EMPTY;
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static dash.logic.parser.CliSyntax.PREFIX_TAG;
 import static java.util.Objects.requireNonNull;
 
@@ -40,6 +41,8 @@ public class TagPersonCommandParser implements Parser<TagPersonCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     TagPersonCommand.MESSAGE_USAGE),
                     pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();

--- a/src/main/java/dash/logic/parser/taskcommand/AddTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/AddTaskCommandParser.java
@@ -41,7 +41,14 @@ public class AddTaskCommandParser implements ParserRequiringPersonList<AddTaskCo
                 ArgumentTokenizer.tokenize(args, PREFIX_TASK_DESCRIPTION, PREFIX_TASK_DATE, PREFIX_PERSON, PREFIX_TAG);
         boolean isDescriptionPrefixPresent = argMultimap.getValue(PREFIX_TASK_DESCRIPTION).isPresent();
         boolean isTaskDatePrefixPresent = argMultimap.getValue(PREFIX_TASK_DATE).isPresent();
-        Set<Index> personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+        Set<Index> personIndices;
+        try {
+            personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTaskCommand.MESSAGE_USAGE));
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
         Set<Person> people = new HashSet<>();
         TaskDate taskDate;
 
@@ -51,7 +58,7 @@ public class AddTaskCommandParser implements ParserRequiringPersonList<AddTaskCo
         }
         for (Index index : personIndices) {
             if (index.getZeroBased() < 0 || index.getZeroBased() >= filteredPersonList.size()) {
-                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX + "\n" + AddTaskCommand.MESSAGE_USAGE);
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
             people.add(filteredPersonList.get(index.getZeroBased()));
         }

--- a/src/main/java/dash/logic/parser/taskcommand/AssignPeopleCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/AssignPeopleCommandParser.java
@@ -3,6 +3,7 @@ package dash.logic.parser.taskcommand;
 import static dash.commons.core.Messages.MESSAGE_ARGUMENT_EMPTY;
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static dash.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static dash.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 import static dash.logic.parser.CliSyntax.PREFIX_PERSON;
 import static java.util.Objects.requireNonNull;
 
@@ -40,6 +41,8 @@ public class AssignPeopleCommandParser implements ParserRequiringPersonList<Assi
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AssignPeopleCommand.MESSAGE_USAGE),
                     pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();
@@ -48,12 +51,20 @@ public class AssignPeopleCommandParser implements ParserRequiringPersonList<Assi
             if (argMultimap.getValue(PREFIX_PERSON).get().isEmpty()) {
                 throw new ParseException(MESSAGE_ARGUMENT_EMPTY);
             }
-            Set<Index> personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+            Set<Index> personIndices;
+            try {
+                personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+            } catch (ParseException pe) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AssignPeopleCommand.MESSAGE_USAGE),
+                        pe);
+            } catch (NumberFormatException nfe) {
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
             Set<Person> people = new HashSet<>();
             for (Index i : personIndices) {
                 if (i.getZeroBased() < 0 || i.getZeroBased() >= filteredPersonList.size()) {
-                    throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX + "\n"
-                            + AssignPeopleCommand.MESSAGE_USAGE);
+                    throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
                 }
                 people.add(filteredPersonList.get(i.getZeroBased()));
             }

--- a/src/main/java/dash/logic/parser/taskcommand/CompleteTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/CompleteTaskCommandParser.java
@@ -1,6 +1,7 @@
 package dash.logic.parser.taskcommand;
 
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 
 import dash.commons.core.index.Index;
 import dash.logic.commands.taskcommand.CompleteTaskCommand;
@@ -27,6 +28,8 @@ public class CompleteTaskCommandParser implements Parser<CompleteTaskCommand> {
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CompleteTaskCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
     }
 }

--- a/src/main/java/dash/logic/parser/taskcommand/DeleteTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/DeleteTaskCommandParser.java
@@ -1,6 +1,7 @@
 package dash.logic.parser.taskcommand;
 
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 
 import dash.commons.core.index.Index;
 import dash.logic.commands.taskcommand.DeleteTaskCommand;
@@ -27,6 +28,8 @@ public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE), pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
     }
 }

--- a/src/main/java/dash/logic/parser/taskcommand/EditTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/EditTaskCommandParser.java
@@ -3,6 +3,7 @@ package dash.logic.parser.taskcommand;
 import static dash.commons.core.Messages.MESSAGE_ARGUMENT_EMPTY;
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static dash.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static dash.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 import static dash.logic.parser.CliSyntax.PREFIX_PERSON;
 import static dash.logic.parser.CliSyntax.PREFIX_TAG;
 import static dash.logic.parser.CliSyntax.PREFIX_TASK_DATE;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import dash.commons.core.index.Index;
+import dash.logic.commands.taskcommand.AssignPeopleCommand;
 import dash.logic.commands.taskcommand.EditTaskCommand;
 import dash.logic.commands.taskcommand.EditTaskCommand.EditTaskDescriptor;
 import dash.logic.parser.ArgumentMultimap;
@@ -53,6 +55,8 @@ public class EditTaskCommandParser implements ParserRequiringPersonList<EditTask
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditTaskCommand.MESSAGE_USAGE),
                     pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();
@@ -70,12 +74,20 @@ public class EditTaskCommandParser implements ParserRequiringPersonList<EditTask
             if (argMultimap.getValue(PREFIX_PERSON).get().isEmpty()) {
                 throw new ParseException(MESSAGE_ARGUMENT_EMPTY);
             }
-            Set<Index> personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+            Set<Index> personIndices;
+            try {
+                personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+            } catch (ParseException pe) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AssignPeopleCommand.MESSAGE_USAGE),
+                        pe);
+            } catch (NumberFormatException nfe) {
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
             Set<Person> people = new HashSet<>();
             for (Index i : personIndices) {
                 if (i.getZeroBased() < 0 || i.getZeroBased() >= filteredPersonList.size()) {
-                    throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX + "\n"
-                            + EditTaskCommand.MESSAGE_USAGE);
+                    throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
                 }
                 people.add(filteredPersonList.get(i.getZeroBased()));
             }

--- a/src/main/java/dash/logic/parser/taskcommand/FindTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/FindTaskCommandParser.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import dash.commons.core.index.Index;
+import dash.logic.commands.taskcommand.AssignPeopleCommand;
 import dash.logic.commands.taskcommand.FindTaskCommand;
 import dash.logic.commands.taskcommand.FindTaskCommand.FindTaskDescriptor;
 import dash.logic.parser.ArgumentMultimap;
@@ -91,22 +92,22 @@ public class FindTaskCommandParser implements ParserRequiringPersonList<FindTask
             if (argMultimap.getValue(PREFIX_PERSON).get().isEmpty()) {
                 throw new ParseException(MESSAGE_ARGUMENT_EMPTY);
             }
-            try {
-                index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON).get());
-            } catch (ParseException pe) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        FindTaskCommand.MESSAGE_USAGE),
-                        pe);
-            }
-
             List<String> personKeywords = new ArrayList<>();
             if (argMultimap.getValue(PREFIX_PERSON).isPresent()) {
-                Set<Index> personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+                Set<Index> personIndices;
+                try {
+                    personIndices = ParserUtil.parsePersonIndex(argMultimap.getAllValues(PREFIX_PERSON));
+                } catch (ParseException pe) {
+                    throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            AssignPeopleCommand.MESSAGE_USAGE),
+                            pe);
+                } catch (NumberFormatException nfe) {
+                    throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                }
                 Set<String> peopleNames = new HashSet<>();
                 for (Index i : personIndices) {
                     if (i.getZeroBased() < 0 || i.getZeroBased() >= filteredPersonList.size()) {
-                        throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX + "\n"
-                                + FindTaskCommand.MESSAGE_USAGE);
+                        throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
                     }
                     Person person = (filteredPersonList.get(i.getZeroBased()));
                     peopleNames.add(person.getName().fullName);

--- a/src/main/java/dash/logic/parser/taskcommand/TagTaskCommandParser.java
+++ b/src/main/java/dash/logic/parser/taskcommand/TagTaskCommandParser.java
@@ -2,6 +2,7 @@ package dash.logic.parser.taskcommand;
 
 import static dash.commons.core.Messages.MESSAGE_ARGUMENT_EMPTY;
 import static dash.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static dash.commons.core.Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX;
 import static dash.logic.parser.CliSyntax.PREFIX_TAG;
 import static java.util.Objects.requireNonNull;
 
@@ -41,6 +42,8 @@ public class TagTaskCommandParser implements Parser<TagTaskCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     TagTaskCommand.MESSAGE_USAGE),
                     pe);
+        } catch (NumberFormatException nfe) {
+            throw new ParseException(MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();

--- a/src/test/java/dash/commons/util/StringUtilTest.java
+++ b/src/test/java/dash/commons/util/StringUtilTest.java
@@ -11,39 +11,34 @@ import dash.testutil.Assert;
 
 public class StringUtilTest {
 
-    //---------------- Tests for isNonZeroUnsignedInteger --------------------------------------
+    //---------------- Tests for isNumeric --------------------------------------
 
     @Test
-    public void isNonZeroUnsignedInteger() {
-
+    public void isNumeric() {
         // EP: empty strings
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("")); // Boundary value
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("  "));
+        assertFalse(StringUtil.isNumeric("")); // Boundary value
+        assertFalse(StringUtil.isNumeric("  "));
 
         // EP: not a number
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("a"));
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("aaa"));
+        assertFalse(StringUtil.isNumeric("a"));
+        assertFalse(StringUtil.isNumeric("aaa"));
+        assertFalse(StringUtil.isNumeric("p/1"));
 
-        // EP: zero
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("0"));
-
-        // EP: zero as prefix
-        assertTrue(StringUtil.isNonZeroUnsignedInteger("01"));
-
-        // EP: signed numbers
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("-1"));
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("+1"));
+        // EP: leading character not minus sign
+        assertFalse(StringUtil.isNumeric("+1"));
+        assertFalse(StringUtil.isNumeric("/1"));
 
         // EP: numbers with white space
-        assertFalse(StringUtil.isNonZeroUnsignedInteger(" 10 ")); // Leading/trailing spaces
-        assertFalse(StringUtil.isNonZeroUnsignedInteger("1 0")); // Spaces in the middle
+        assertFalse(StringUtil.isNumeric(" 10 ")); // Leading/trailing spaces
+        assertFalse(StringUtil.isNumeric("1 0")); // Spaces in the middle
 
-        // EP: number larger than Integer.MAX_VALUE
-        assertFalse(StringUtil.isNonZeroUnsignedInteger(Long.toString(Integer.MAX_VALUE + 1)));
-
-        // EP: valid numbers, should return true
-        assertTrue(StringUtil.isNonZeroUnsignedInteger("1")); // Boundary value
-        assertTrue(StringUtil.isNonZeroUnsignedInteger("10"));
+        // EP: numeric values, should return true
+        assertTrue(StringUtil.isNumeric("1"));
+        assertTrue(StringUtil.isNumeric("10"));
+        assertTrue(StringUtil.isNumeric("01"));
+        assertTrue(StringUtil.isNumeric(Long.toString(Long.MAX_VALUE)));
+        assertTrue(StringUtil.isNumeric("-1"));
+        assertTrue(StringUtil.isNumeric("1.2"));
     }
 
 

--- a/src/test/java/dash/logic/parser/ParserUtilTest.java
+++ b/src/test/java/dash/logic/parser/ParserUtilTest.java
@@ -1,6 +1,5 @@
 package dash.logic.parser;
 
-import static dash.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,9 +46,19 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() {
-        Assert.assertThrows(ParseException.class,
-                MESSAGE_INVALID_INDEX, () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    public void parseIndex_outOfRangeInput_throwsNumberFormatException() {
+        Assert.assertThrows(NumberFormatException.class, () -> ParserUtil.parseIndex(Long.toString(Long.MAX_VALUE)));
+    }
+
+    @Test
+    public void parseIndex_nonPositive_throwsNumberFormatException() {
+        Assert.assertThrows(NumberFormatException.class, () -> ParserUtil.parseIndex("0"));
+        Assert.assertThrows(NumberFormatException.class, () -> ParserUtil.parseIndex("-1"));
+    }
+
+    @Test
+    public void parseIndex_fractional_throwsNumberFormatException() {
+        Assert.assertThrows(NumberFormatException.class, () -> ParserUtil.parseIndex("2.5"));
     }
 
     @Test

--- a/src/test/java/dash/logic/parser/personcommand/EditPersonCommandParserTest.java
+++ b/src/test/java/dash/logic/parser/personcommand/EditPersonCommandParserTest.java
@@ -23,6 +23,7 @@ public class EditPersonCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditPersonCommand.MESSAGE_USAGE);
 
+
     private EditPersonCommandParser parser = new EditPersonCommandParser();
 
     @Test
@@ -40,10 +41,12 @@ public class EditPersonCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        CommandParserTestUtil.assertParseFailure(parser, "-5" + CommandTestUtil.NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser,
+                "-5" + CommandTestUtil.NAME_DESC_AMY, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // zero index
-        CommandParserTestUtil.assertParseFailure(parser, "0" + CommandTestUtil.NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        CommandParserTestUtil.assertParseFailure(parser,
+                "0" + CommandTestUtil.NAME_DESC_AMY, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
         CommandParserTestUtil.assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/dash/logic/parser/taskcommand/AssignPeopleCommandParserTest.java
+++ b/src/test/java/dash/logic/parser/taskcommand/AssignPeopleCommandParserTest.java
@@ -12,7 +12,6 @@ import dash.logic.commands.CommandTestUtil;
 import dash.logic.commands.taskcommand.AssignPeopleCommand;
 import dash.logic.commands.taskcommand.EditTaskCommand;
 import dash.logic.parser.CliSyntax;
-import dash.logic.parser.ParserUtil;
 import dash.model.person.Person;
 import dash.testutil.EditTaskDescriptorBuilder;
 import dash.testutil.TypicalIndexes;
@@ -62,17 +61,16 @@ class AssignPeopleCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailureWithPersonList(parser, "1" + CommandTestUtil.INVALID_PERSON_INDEX, people,
-                ParserUtil.MESSAGE_INVALID_INDEX); // invalid person index
+                MESSAGE_INVALID_FORMAT); // non-numeric person index
 
         assertParseFailureWithPersonList(parser, "1" + PREFIX_EMPTY + "-1", people,
-                ParserUtil.MESSAGE_INVALID_INDEX); // negative person index
+                MESSAGE_INVALID_PERSON_DISPLAYED_INDEX); // negative person index
 
         assertParseFailureWithPersonList(parser, "1" + PREFIX_EMPTY, people,
                 Messages.MESSAGE_ARGUMENT_EMPTY); // no person index
 
         assertParseFailureWithPersonList(parser, "1" + PREFIX_EMPTY + "100", people,
-                MESSAGE_INVALID_PERSON_DISPLAYED_INDEX + "\n"
-                        + AssignPeopleCommand.MESSAGE_USAGE); // out of range person index
+                MESSAGE_INVALID_PERSON_DISPLAYED_INDEX); // out of range person index
 
     }
 

--- a/src/test/java/dash/logic/parser/taskcommand/EditTaskCommandParserTest.java
+++ b/src/test/java/dash/logic/parser/taskcommand/EditTaskCommandParserTest.java
@@ -46,11 +46,11 @@ class EditTaskCommandParserTest {
     public void parse_invalidPreamble_failure() {
         // negative index
         assertParseFailureWithPersonList(parser, "-5" + CommandTestUtil.TASK_DESC_ASSIGNMENT, people,
-                MESSAGE_INVALID_FORMAT);
+                Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
 
         // zero index
         assertParseFailureWithPersonList(parser, "0" + CommandTestUtil.TASK_DESC_ASSIGNMENT, people,
-                MESSAGE_INVALID_FORMAT);
+                Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailureWithPersonList(parser, "1 some random string", people, MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
Adapted isNonZeroUnsignedInteger method in StringUtil to isNumeric. In event of a numeric string which cannot be parsed to an int, the exception is caught separately from non-numeric strings. Hence, when the index out of bounds, negative, or fractional, the error message is "invalid index" rather than "invalid command format".